### PR TITLE
Added "FLAGS(sys.argv)" to fix issue #10

### DIFF
--- a/pysc2/bin/replay_actions.py
+++ b/pysc2/bin/replay_actions.py
@@ -45,7 +45,7 @@ flags.DEFINE_integer("parallel", 1, "How many instances to run in parallel.")
 flags.DEFINE_integer("step_mul", 8, "How many game steps per observation.")
 flags.DEFINE_string("replays", None, "Path to a directory of replays.")
 flags.mark_flag_as_required("replays")
-
+FLAGS(sys.argv)
 
 size = point.Point(16, 16)
 interface = sc_pb.InterfaceOptions(


### PR DESCRIPTION
https://github.com/deepmind/pysc2/issues/10

Tested on windows 10 with python versions 2.7 and 3.6

Also discussed in issue #10, is the differences between Queue and queue. I left the Queue class as is, because there's really no point in changing it. People will just have to change it depending on what ever version of python they want to use.