### PR TITLE
fix queue import for py3 in replay_actions

### DIFF
--- a/pysc2/bin/replay_actions.py
+++ b/pysc2/bin/replay_actions.py
@@ -21,11 +21,14 @@ from __future__ import print_function
 import collections
 import multiprocessing
 import os
-import Queue
 import signal
 import sys
 import threading
 import time
+try:
+    import queue as Queue
+except:
+    import Queue
 
 from future.builtins import range  # pylint: disable=redefined-builtin
 import six


### PR DESCRIPTION
Fixes #10

Since only `Empty` is really used here, alternative fix would be to import it directly, but I'm assuming it wasn't done this way for clarity.