### PR TITLE
instance attributes are defined on __init__

### DIFF
--- a/pysc2/agents/base_agent.py
+++ b/pysc2/agents/base_agent.py
@@ -23,10 +23,14 @@ from pysc2.lib import actions
 class BaseAgent(object):
   """A base agent to write custom scripted agents."""
 
-  def setup(self, obs_spec, action_spec):
+  def __init__(self):
     self.reward = 0
     self.episodes = 0
     self.steps = 0
+    self.obs_spec = None
+    self.action_spec = None
+
+  def setup(self, obs_spec, action_spec):
     self.obs_spec = obs_spec
     self.action_spec = action_spec
 


### PR DESCRIPTION
The base agent class is defining instance attributes outside the `__init__` method

This is based on my experience with the default setup of pylint and pycharm linters.

I don't know if you are following a different convention that does not require this, so I made this pull request just in case.

Thanks,
Luis