### PR TITLE
bug fix : Index Error at pysc2/lib/features.py

### DIFF
--- a/pysc2/lib/features.py
+++ b/pysc2/lib/features.py
@@ -90,7 +90,7 @@ class Feature(collections.namedtuple(
   @sw.decorate
   def color(self, plane):
     if self.clip:
-      plane = np.clip(plane, 0, self.scale - 1)
+      plane = np.clip(plane, 0, self.scale - 2)
     return self.palette[plane]
 
 


### PR DESCRIPTION
This is buf fix reported : https://github.com/deepmind/pysc2/issues/61

np.clip is inclusive, therefore argument `plane` bigger than `self.scale` can cause IndexError. To avoid this, simply clip `(0, self.scale - 2)` rather than `(0, self.scale - 1)`