### PR TITLE
Custom screen size

### DIFF
--- a/pysc2/lib/renderer_human.py
+++ b/pysc2/lib/renderer_human.py
@@ -42,8 +42,8 @@ from s2clientprotocol import sc2api_pb2 as sc_pb
 from s2clientprotocol import spatial_pb2 as sc_spatial
 
 import ctypes
+import os
 
-ctypes.windll.user32.SetProcessDPIAware()
 
 sw = stopwatch.sw
 
@@ -133,6 +133,10 @@ class MousePos(collections.namedtuple("MousePos", ["pos", "type"])):
   """Holds the mouse position in world coordinates and a SurfType."""
   __slots__ = ()
 
+#check if OS is windows based. If True, run SetProcessDPIAware()
+#to correct display resolution issues PR#78
+if os.name == 'nt':
+  ctypes.windll.user32.SetProcessDPIAware()
 
 max_window_size = None
 def _get_max_window_size():  # pylint: disable=g-wrong-blank-lines

--- a/pysc2/lib/renderer_human.py
+++ b/pysc2/lib/renderer_human.py
@@ -41,6 +41,10 @@ from s2clientprotocol import data_pb2 as sc_data
 from s2clientprotocol import sc2api_pb2 as sc_pb
 from s2clientprotocol import spatial_pb2 as sc_spatial
 
+import ctypes
+
+ctypes.windll.user32.SetProcessDPIAware()
+
 sw = stopwatch.sw
 
 render_lock = threading.Lock()  # Serialize all window/render operations.


### PR DESCRIPTION
Ok here's my go at providing an optional argument to allow custom screen size scaling requested in #40.

The optional parameter simply abstracts the hard coded screen scaling constant here: https://github.com/deepmind/pysc2/blob/master/pysc2/lib/renderer_human.py#L139 into a user adjustable parameter. I've updated play.py and agent.py to accept --window_scaling as an argument and this flows through to the RenderHuman object and is passed in as a parameter to the _get_max_window_size function to be used in the above line. I don't think there should be any gotchyas, but let me know if you have any questions. I added a note about the argument in the environment.md docs.

Thanks @tewalds and DeepMind for the sweet repo, looking forward to playing with it.

-Cole