### PR TITLE
fix action spec for pickle

### DIFF
--- a/pysc2/lib/actions.py
+++ b/pysc2/lib/actions.py
@@ -329,6 +329,8 @@ class Functions(object):
       raise ValueError("Function names must be unique.")
 
   def __getattr__(self, name):
+    if name.startswith("__") and name.endswith("__"):
+      return super(Functions, self).__getattr__(name)
     return self._func_dict[name]
 
   def __getitem__(self, key):

--- a/pysc2/lib/features_test.py
+++ b/pysc2/lib/features_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 from future.builtins import range  # pylint: disable=redefined-builtin
+import pickle
 import numpy
 import six
 from pysc2.lib import actions
@@ -269,6 +270,11 @@ class FeaturesTest(basetest.TestCase):
           self.assertEqual(func_call, func_call2, msg=sc2_action)
         self.assertEqual(sc2_action, sc2_action2)
 
+  def testCanPickleSpecs(self):
+    feats = features.Features(screen_size_px=(84, 80), minimap_size_px=(64, 67))
+
+    pickle.loads(pickle.dumps(feats.action_spec()))
+    pickle.loads(pickle.dumps(feats.observation_spec()))
 
 if __name__ == "__main__":
   basetest.main()


### PR DESCRIPTION
Currently if you try to pickle output from `SC2Env::action_spec()` it will crash with a cryptic error, which turns out to be caused by pickle trying to access internal magic attribute (of the type `__name__`) in the `Functions` object and it being intercepted by `__getattr__` and subsequently crashing due to `self._func_dict` missing it.
 
So I propose a fix as per [this answer](https://stackoverflow.com/a/6416080).

A use case for using pickle in the first place is running multiple SC2Env instances and communicating with them through Pythons `multiprocessing.Process` send / recv.