### PR TITLE
[WIP] Abstracted Replay Data Parsers

### DIFF
--- a/pysc2/bin/replay_actions.py
+++ b/pysc2/bin/replay_actions.py
@@ -61,11 +61,6 @@ size.assign_to(interface.feature_layer.resolution)
 size.assign_to(interface.feature_layer.minimap_resolution)
 
 
-def sorted_dict_str(d):
-  return "{%s}" % ", ".join("%s: %s" % (k, d[k])
-                            for k in sorted(d, key=d.get, reverse=True))
-
-
 class ProcessStats(object):
   """Stats for a worker process."""
 
@@ -74,7 +69,7 @@ class ProcessStats(object):
     self.time = time.time()
     self.stage = ""
     self.replay = ""
-    self.replay_stats = parser_cls
+    self.replay_stats = parser_cls()
 
   def update(self, stage):
     self.time = time.time()
@@ -114,7 +109,7 @@ class ReplayProcessor(multiprocessing.Process):
     self.run_config = run_config
     self.replay_queue = replay_queue
     self.stats_queue = stats_queue
-    self.parser_cls = parser_cls
+    self.parser_cls = parser_cls()
 
   def run(self):
     signal.signal(signal.SIGTERM, lambda a, b: sys.exit())  # Exit quietly.
@@ -255,7 +250,7 @@ def stats_printer(stats_queue, parser_cls):
       except queue.Empty:
         pass
 
-    replay_stats = parser_cls
+    replay_stats = parser_cls()
     for s in proc_stats:
       replay_stats.merge(s.replay_stats)
 

--- a/pysc2/lib/renderer_human.py
+++ b/pysc2/lib/renderer_human.py
@@ -41,6 +41,10 @@ from s2clientprotocol import data_pb2 as sc_data
 from s2clientprotocol import sc2api_pb2 as sc_pb
 from s2clientprotocol import spatial_pb2 as sc_spatial
 
+import ctypes
+
+ctypes.windll.user32.SetProcessDPIAware()
+
 sw = stopwatch.sw
 
 render_lock = threading.Lock()  # Serialize all window/render operations.

--- a/pysc2/replay_parsers/__init__.py
+++ b/pysc2/replay_parsers/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pysc2/replay_parsers/base_parser.py
+++ b/pysc2/replay_parsers/base_parser.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 """A base replay parser to write custom replay data scrappers."""
 
+import collections
+import six
+
+def sorted_dict_str(d):
+  return "{%s}" % ", ".join("%s: %s" % (k, d[k])
+                            for k in sorted(d, key=d.get, reverse=True))
 
 class BaseParser(object):
   """Summary stats of the replays seen so far."""

--- a/pysc2/replay_parsers/base_parser.py
+++ b/pysc2/replay_parsers/base_parser.py
@@ -1,0 +1,76 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A base replay parser to write custom replay data scrappers."""
+
+
+class BaseParser(object):
+  """Summary stats of the replays seen so far."""
+
+  def __init__(self):
+    self.replays = 0
+    self.steps = 0
+    self.camera_move = 0
+    self.select_pt = 0
+    self.select_rect = 0
+    self.control_group = 0
+    self.maps = collections.defaultdict(int)
+    self.races = collections.defaultdict(int)
+    self.unit_ids = collections.defaultdict(int)
+    self.valid_abilities = collections.defaultdict(int)
+    self.made_abilities = collections.defaultdict(int)
+    self.valid_actions = collections.defaultdict(int)
+    self.made_actions = collections.defaultdict(int)
+    self.crashing_replays = set()
+    self.invalid_replays = set()
+
+  def merge(self, other):
+    """Merge another ReplayStats into this one."""
+    def merge_dict(a, b):
+      for k, v in six.iteritems(b):
+        a[k] += v
+
+    self.replays += other.replays
+    self.steps += other.steps
+    self.camera_move += other.camera_move
+    self.select_pt += other.select_pt
+    self.select_rect += other.select_rect
+    self.control_group += other.control_group
+    merge_dict(self.maps, other.maps)
+    merge_dict(self.races, other.races)
+    merge_dict(self.unit_ids, other.unit_ids)
+    merge_dict(self.valid_abilities, other.valid_abilities)
+    merge_dict(self.made_abilities, other.made_abilities)
+    merge_dict(self.valid_actions, other.valid_actions)
+    merge_dict(self.made_actions, other.made_actions)
+    self.crashing_replays |= other.crashing_replays
+    self.invalid_replays |= other.invalid_replays
+
+  def __str__(self):
+    len_sorted_dict = lambda s: (len(s), sorted_dict_str(s))
+    len_sorted_list = lambda s: (len(s), sorted(s))
+    return "\n\n".join((
+        "Replays: %s, Steps total: %s" % (self.replays, self.steps),
+        "Camera move: %s, Select pt: %s, Select rect: %s, Control group: %s" % (
+            self.camera_move, self.select_pt, self.select_rect,
+            self.control_group),
+        "Maps: %s\n%s" % len_sorted_dict(self.maps),
+        "Races: %s\n%s" % len_sorted_dict(self.races),
+        "Unit ids: %s\n%s" % len_sorted_dict(self.unit_ids),
+        "Valid abilities: %s\n%s" % len_sorted_dict(self.valid_abilities),
+        "Made abilities: %s\n%s" % len_sorted_dict(self.made_abilities),
+        "Valid actions: %s\n%s" % len_sorted_dict(self.valid_actions),
+        "Made actions: %s\n%s" % len_sorted_dict(self.made_actions),
+        "Crashing replays: %s\n%s" % len_sorted_list(self.crashing_replays),
+        "Invalid replays: %s\n%s" % len_sorted_list(self.invalid_replays),
+    ))

--- a/pysc2/replay_parsers/random_agent.py
+++ b/pysc2/replay_parsers/random_agent.py
@@ -1,0 +1,34 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A random agent for starcraft."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy
+
+from pysc2.agents import base_agent
+from pysc2.lib import actions
+
+
+class RandomAgent(base_agent.BaseAgent):
+  """A random agent for starcraft."""
+
+  def step(self, obs):
+    super(RandomAgent, self).step(obs)
+    function_id = numpy.random.choice(obs.observation["available_actions"])
+    args = [[numpy.random.randint(0, size) for size in arg.sizes]
+            for arg in self.action_spec.functions[function_id].args]
+    return actions.FunctionCall(function_id, args)

--- a/pysc2/replay_parsers/scripted_agent.py
+++ b/pysc2/replay_parsers/scripted_agent.py
@@ -1,0 +1,92 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Scripted agents."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy
+
+from pysc2.agents import base_agent
+from pysc2.lib import actions
+from pysc2.lib import features
+
+_PLAYER_RELATIVE = features.SCREEN_FEATURES.player_relative.index
+_PLAYER_FRIENDLY = 1
+_PLAYER_NEUTRAL = 3  # beacon/minerals
+_PLAYER_HOSTILE = 4
+_NO_OP = actions.FUNCTIONS.no_op.id
+_MOVE_SCREEN = actions.FUNCTIONS.Move_screen.id
+_ATTACK_SCREEN = actions.FUNCTIONS.Attack_screen.id
+_SELECT_ARMY = actions.FUNCTIONS.select_army.id
+_NOT_QUEUED = [0]
+_SELECT_ALL = [0]
+
+
+class MoveToBeacon(base_agent.BaseAgent):
+  """An agent specifically for solving the MoveToBeacon map."""
+
+  def step(self, obs):
+    super(MoveToBeacon, self).step(obs)
+    if _MOVE_SCREEN in obs.observation["available_actions"]:
+      player_relative = obs.observation["screen"][_PLAYER_RELATIVE]
+      neutral_y, neutral_x = (player_relative == _PLAYER_NEUTRAL).nonzero()
+      if not neutral_y.any():
+        return actions.FunctionCall(_NO_OP, [])
+      target = [int(neutral_x.mean()), int(neutral_y.mean())]
+      return actions.FunctionCall(_MOVE_SCREEN, [_NOT_QUEUED, target])
+    else:
+      return actions.FunctionCall(_SELECT_ARMY, [_SELECT_ALL])
+
+
+class CollectMineralShards(base_agent.BaseAgent):
+  """An agent specifically for solving the CollectMineralShards map."""
+
+  def step(self, obs):
+    super(CollectMineralShards, self).step(obs)
+    if _MOVE_SCREEN in obs.observation["available_actions"]:
+      player_relative = obs.observation["screen"][_PLAYER_RELATIVE]
+      neutral_y, neutral_x = (player_relative == _PLAYER_NEUTRAL).nonzero()
+      player_y, player_x = (player_relative == _PLAYER_FRIENDLY).nonzero()
+      if not neutral_y.any() or not player_y.any():
+        return actions.FunctionCall(_NO_OP, [])
+      player = [int(player_x.mean()), int(player_y.mean())]
+      closest, min_dist = None, None
+      for p in zip(neutral_x, neutral_y):
+        dist = numpy.linalg.norm(numpy.array(player) - numpy.array(p))
+        if not min_dist or dist < min_dist:
+          closest, min_dist = p, dist
+      return actions.FunctionCall(_MOVE_SCREEN, [_NOT_QUEUED, closest])
+    else:
+      return actions.FunctionCall(_SELECT_ARMY, [_SELECT_ALL])
+
+
+class DefeatRoaches(base_agent.BaseAgent):
+  """An agent specifically for solving the DefeatRoaches map."""
+
+  def step(self, obs):
+    super(DefeatRoaches, self).step(obs)
+    if _ATTACK_SCREEN in obs.observation["available_actions"]:
+      player_relative = obs.observation["screen"][_PLAYER_RELATIVE]
+      roach_y, roach_x = (player_relative == _PLAYER_HOSTILE).nonzero()
+      if not roach_y.any():
+        return actions.FunctionCall(_NO_OP, [])
+      index = numpy.argmax(roach_y)
+      target = [roach_x[index], roach_y[index]]
+      return actions.FunctionCall(_ATTACK_SCREEN, [_NOT_QUEUED, target])
+    elif _SELECT_ARMY in obs.observation["available_actions"]:
+      return actions.FunctionCall(_SELECT_ARMY, [_SELECT_ALL])
+    else:
+      return actions.FunctionCall(_NO_OP, [])


### PR DESCRIPTION
PR to implement an abstraction of the replay_actions module to separate running the replays and the data scrapping as per issue #51 , similar to how running agents is abstracted to allow for arbitrary user written agents. This will likely be a fairly large redesign, so PR is currently a Work In Progress to get things started. Current commit is proof of concept of abstracting a parser class from the replay setup to run the action stats scrapping of the current replay_actions script.