### PR TITLE
[CollectMineralShardsFeatureUnits] Fair selection of units

### DIFF
--- a/pysc2/agents/scripted_agent.py
+++ b/pysc2/agents/scripted_agent.py
@@ -87,7 +87,7 @@ class CollectMineralShardsFeatureUnits(base_agent.BaseAgent):
 
   def reset(self):
     super(CollectMineralShardsFeatureUnits, self).reset()
-    self._current_marine = 0
+    self._marine_selected = False
     self._previous_mineral_xy = [-1, -1]
 
   def step(self, obs):
@@ -96,11 +96,12 @@ class CollectMineralShardsFeatureUnits(base_agent.BaseAgent):
                if unit.alliance == _PLAYER_SELF]
     if not marines:
       return FUNCTIONS.no_op()
-    marine_unit = marines[self._current_marine]
+    marine_unit = next((m for m in marines if m.is_selected == self._marine_selected), marines[0])
     marine_xy = [marine_unit.x, marine_unit.y]
 
     if not marine_unit.is_selected:
       # Nothing selected or the wrong marine is selected.
+      self._marine_selected = True
       return FUNCTIONS.select_point("select", marine_xy)
 
     if FUNCTIONS.Move_screen.id in obs.observation.available_actions:
@@ -119,7 +120,7 @@ class CollectMineralShardsFeatureUnits(base_agent.BaseAgent):
         closest_mineral_xy = minerals[numpy.argmin(distances)]
 
         # Swap to the other marine.
-        self._current_marine = 1 - self._current_marine
+        self._marine_selected = False
         self._previous_mineral_xy = closest_mineral_xy
         return FUNCTIONS.Move_screen("now", closest_mineral_xy)
 


### PR DESCRIPTION
This is in relation to issue #153.

As the order of units in `obs.observation.feature_units` is indeterminate across timesteps, a previously stored list index cannot be used to refer to the same unit in a different timestep.

The proposed change selects units based on whether they are currently selected, which is a property of the unit (`is_selected`) and persists across timesteps.