### PR TITLE
fix ldconfig on chromebook

### DIFF
--- a/pysc2/run_configs/platforms.py
+++ b/pysc2/run_configs/platforms.py
@@ -203,7 +203,7 @@ class Linux(LocalBase):
 
     # Figure out whether the various GL libraries exist since SC2 sometimes
     # fails if you ask to use a library that doesn't exist.
-    libs = subprocess.check_output(["ldconfig", "-p"]).decode()
+    libs = subprocess.check_output(["/sbin/ldconfig", "-p"]).decode()
     libs = {lib.strip().split()[0] for lib in libs.split("\n") if lib}
     if "libEGL.so" in libs:  # Prefer hardware rendering.
       extra_args += ["-eglpath", "libEGL.so"]


### PR DESCRIPTION
this will fix a error on chromebook that 'cannot find ldconfig'