### PR TITLE
Don't call xrandr on OS X

### DIFF
--- a/pysc2/lib/renderer_human.py
+++ b/pysc2/lib/renderer_human.py
@@ -24,6 +24,7 @@ import itertools
 from absl import logging
 import math
 import os
+import platform
 import re
 import subprocess
 import threading
@@ -195,7 +196,7 @@ class PastAction(collections.namedtuple("PastAction", [
 
 def _get_desktop_size():
   """Get the desktop size."""
-  if os.name == "posix":
+  if platform.system() == "Linux":
     try:
       xrandr_query = subprocess.check_output(["xrandr", "--query"])
       sizes = re.findall(r"\bconnected primary (\d+)x(\d+)", str(xrandr_query))


### PR DESCRIPTION
Usual OS X instalation doesn't contain the xrandr utility. One can bring
it only by installing XQuartz and even after it the utility doesn't work
well with the native windows.

Use more precise checkout (os.name == "posix" in OS X as it is
posix-compliant) to identify the Linux system and avoid redundant call.