### PR TITLE
[WIP] fix NamedNumpyArray bug, make comma before dtype optional

### DIFF
--- a/pysc2/lib/named_array.py
+++ b/pysc2/lib/named_array.py
@@ -212,7 +212,7 @@ class NamedNumpyArray(np.ndarray):
 
     # "NamedNumpyArray([1, 3, 6], dtype=int32)" ->
     # ["NamedNumpyArray", "[1, 3, 6]", ", dtype=int32"]
-    matches = re.findall(r"^(\w+)\(([\d\., \n\[\]]*)(, \w+=.+)?\)$",
+    matches = re.findall(r"^(\w+)\(([\d\., \n\[\]]*)(,? \w+=.+)?\)$",
                          np.array_repr(self))[0]
     return "%s(%s, %s%s)" % (
         matches[0], matches[1], names, matches[2])

--- a/pysc2/lib/named_array_test.py
+++ b/pysc2/lib/named_array_test.py
@@ -284,6 +284,12 @@ class NamedArrayTest(parameterized.TestCase):
     self.assertIn("49", str(a))
     self.assertIn("49", repr(a))
 
+  def test_long_string(self):
+    a = named_array.NamedNumpyArray([0, 0, 0, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [str(i) for i in range(13)], dtype=np.int32)
+    self.assertEqual(repr(a), ("NamedNumpyArray([ 0,  0,  0, 50,  0,  0,  0,  0,  0,  0,  0,  0,  0], "
+                               "['0', '1', '2', '3', '4', '...', '8', '9', '10', '11', '12'] dtype=int32)"))
+
   def test_pickle(self):
     arr = named_array.NamedNumpyArray([1, 3, 6], ["a", "b", "c"])
     pickled = pickle.loads(pickle.dumps(arr))


### PR DESCRIPTION
Fixed #241 allowing matches on inputs such as:

```
NamedNumpyArray([ 0,  0,  0, 50,  0,  0,  0,  0,  0,  0,  0,  0,  0],
                dtype=int32)
```