### PR TITLE
Fix path

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ PySC2 has many maps pre-configured, but they need to be downloaded into the SC2
 
 Download the [ladder maps](https://github.com/Blizzard/s2client-proto#downloads)
 and the [mini games](https://github.com/deepmind/pysc2/releases/download/v1.2/mini_games.zip)
-and extract them to your `StarcraftII/Maps/` directory.
+and extract them to your `StarCraftII/Maps/` directory.
 
 ## Run an agent
 


### PR DESCRIPTION
> By default, PySC2 expects the game to live in ~/StarCraftII/