### PR TITLE
Update colors.py to Python 3.11+

### DIFF
--- a/pysc2/lib/colors.py
+++ b/pysc2/lib/colors.py
@@ -118,7 +118,7 @@ def smooth_hue_palette(scale):
 
 def shuffled_hue(scale):
   palette = list(smooth_hue_palette(scale))
-  random.shuffle(palette, lambda: 0.5)  # Return a fixed shuffle
+  random.Random(21).shuffle(palette)  # Return a fixed shuffle
   return numpy.array(palette)
 
 


### PR DESCRIPTION
random.shuffle() does not take lambda as a parameter anymore since Python 3.9 and crashes Python 3.11+. This small fix provides the same functionality using a fixed seed RNG instead.