### PR TITLE
Update colors.py to support Python 3.9 and later

### DIFF
--- a/pysc2/lib/colors.py
+++ b/pysc2/lib/colors.py
@@ -118,7 +118,8 @@ def smooth_hue_palette(scale):
 
 def shuffled_hue(scale):
   palette = list(smooth_hue_palette(scale))
-  random.Random(21).shuffle(palette)  # Return a fixed shuffle
+  random.seed(21) # provide a fixed seed (modify as necessary) to support Python 3.9+
+  random.shuffle(palette)  # Return a fixed shuffle
   return numpy.array(palette)
 
 


### PR DESCRIPTION
The random.shuffle function in Python's standard library doesn't take a second argument in Python versions 3.9 and onwards. 

Previously, random.shuffle allowed for a random generator function as its second argument, but this feature was deprecated in Python 3.9 and has been removed in Python 3.10 and onwards.

Without the patch, we're presented with a Traceback:

```
  File "../lib/python3.11/site-packages/pysc2/lib/colors.py", line 224, in categorical
    palette = shuffled_hue(palette_size)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "../lib/python3.11/site-packages/pysc2/lib/colors.py", line 121, in shuffled_hue
    random.shuffle(palette, lambda: 0.5)  # Return a fixed shuffle
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

TypeError: Random.shuffle() takes 2 positional arguments but 3 were given

```